### PR TITLE
add delay and default admin detection

### DIFF
--- a/Proactive Remediation/Detection.ps1
+++ b/Proactive Remediation/Detection.ps1
@@ -19,8 +19,12 @@
 
     Version history:
     1.0.0 - (2020-09-14) Script created
+    1.0.1 - (2021-12-17) Add delay
 #>
 Process {
+    # Delay for Detection
+    $Delay = 30
+
     # Create new event log if it doesn't already exist
     $EventLogName = "CloudLAPS-Client"
     $EventLogSource = "CloudLAPS-Client"
@@ -33,7 +37,10 @@ Process {
             Write-Warning -Message "Failed to create new event log. Error message: $($_.Exception.Message)"
         }
     }
+    if((Get-EventLog -LogName $EventLogName -InstanceId 40)[0].TimeGenerated -ge (Get-Date).AddDays($Delay)){
+        exit 1
+    }
 
     # Trigger remediation script
-    exit 1
+    exit 0
 }

--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -19,6 +19,7 @@
     Version history:
     1.0.0 - (2020-09-14) Script created
     1.0.1 - (2021-10-07) Updated with output for extended details in MEM portal
+    1.0.2 - (2021-12-17) Add detection of default local admin for different languages
 #>
 Process {
     # Functions
@@ -236,8 +237,15 @@ Process {
         }
     }
 
-    # Define the local administrator user name
-    $LocalAdministratorName = "<Enter the name of the local administrator account>"
+    # Define the local administrator user name on line 247 or select to use default by changing 241 to $true
+    $UseDefaultAdministrator = $false
+    if($UseDefaultAdministrator){
+        $LocalAdministratorName = (Get-LocalUser | Where-Object {$_.SID -like "*-500"}).Name
+        Enable-LocalUser -Name $LocalAdministratorName
+    }
+    else{
+        $LocalAdministratorName = "LocalAdmin"
+    }
 
     # Construct the required URI for the Azure Function URL
     $URI = "<Enter Azure Functions URI>"


### PR DESCRIPTION
Adds 2 features.
A delay option to the detection so remediation doesn't run every time.  Only when delay from last successful rotation (detected by event viewer query) is matched.
A detection method for the default administrator account, and a variable to request to use it instead of a new account. This is to fix issues with different languages (fr-CA the local admin account is names Administrateurs).